### PR TITLE
Fix dependency declaration for @angular/common@10

### DIFF
--- a/projects/ng-keyboard-shortcuts/package.json
+++ b/projects/ng-keyboard-shortcuts/package.json
@@ -17,7 +17,7 @@
   "bugs": "https://github.com/omridevk/ng-keyboard-shortcuts/issues",
   "peerDependencies": {
     "@angular/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
-    "@angular/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || 10.0.0",
+    "@angular/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
     "rxjs": "^6.0.0",
     "zone.js": "^0.9.1 || ^0.10.2",
     "core-js": "^2.5.4"


### PR DESCRIPTION
The dependency specification line is missing the `^` symbol and thus only allows `@angular/common@10.0.0`. But there is a version 10.0.9 live already. Any `ng update` calls fail because of that:

```
$ ng update @angular/core@10 @angular/cli@10 @angular/common@10
Your global Angular CLI version (10.0.5) is greater than your local
version (9.1.12). The local Angular CLI version is used.

To disable this warning use "ng config -g cli.warnings.versionMismatch false".
The installed local Angular CLI version is older than the latest stable version.
Installing a temporary version to perform the update.
Installing packages for tooling via npm.
Installed packages for tooling via npm.
Using package manager: 'npm'
Collecting installed dependencies...
Found 65 dependencies.
Fetching dependency metadata from registry...
                  Package "ng-keyboard-shortcuts" has an incompatible peer dependency to "@angular/common" (requires "^7.0.0 || ^8.0.0 || ^9.0.0 || 10.0.0" (extended), would install "10.0.9").
✖ Migration failed: Incompatible peer dependencies found.
Peer dependency warnings when installing dependencies means that those dependencies might not work correctly together.
You can use the '--force' option to ignore incompatible peer dependencies and instead address these warnings later.
  See "/private/var/folders/0z/101fmx1n5hl3g6l0vrn5g9qh0000gn/T/ng-UKO9VI/angular-errors.log" for further details.
```