### PR TITLE
Fix ng-keyboard-shortcuts component disabled property not working

### DIFF
--- a/projects/ng-keyboard-shortcuts/src/lib/ng-keyboard-shortcuts.component.ts
+++ b/projects/ng-keyboard-shortcuts/src/lib/ng-keyboard-shortcuts.component.ts
@@ -84,7 +84,9 @@ export class KeyboardShortcutsComponent implements OnInit, AfterViewInit, OnChan
         if (this.clearIds) {
             this.keyboard.remove(this.clearIds);
         }
-        setTimeout(() => this.clearIds = this.keyboard.add(changes.shortcuts.currentValue));
+        if (!this._disabled) {
+            setTimeout(() => (this.clearIds = this.keyboard.add(changes.shortcuts.currentValue)));
+        }
     }
 
     /**

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,4 +1,4 @@
-<ng-keyboard-shortcuts [shortcuts]="shortcuts"></ng-keyboard-shortcuts>
+<ng-keyboard-shortcuts [disabled]="directiveDisabled" [shortcuts]="shortcuts"></ng-keyboard-shortcuts>
 <div class="wrapper">
   <mat-card class="example-card">
     <mat-card-header>


### PR DESCRIPTION
Fixed a bug that prevent disabled property to be recognized on ng-keyboard-shortcuts component if the initial value is false. 

In our case we wanted to selectively enabled shortcuts. In ngOnInit of our component we initialized the shortcuts array and bound a property with the value false to disabled. This did not work since the setter for disabled got triggered before the array was set. So no resetIds were available.