### PR TITLE
fix dependencies of parent project being pulled into lib

### DIFF
--- a/libs/ng-keyboard-shortcuts/package.json
+++ b/libs/ng-keyboard-shortcuts/package.json
@@ -16,7 +16,9 @@
   "repository": "github.com/omridevk/ng-keyboard-shortcuts",
   "bugs": "https://github.com/omridevk/ng-keyboard-shortcuts/issues",
   "peerDependencies": {
+    "@angular/animations": ">=9.0.0",
     "@angular/common": ">=9.0.0",
+    "@angular/compiler": ">=9.0.0",
     "@angular/core": ">=9.0.0",
     "@angular/platform-browser": ">=9.0.0",
     "rxjs": ">=6.0.0"


### PR DESCRIPTION
The lib has some dependencies on `@angular/animations`. Since this is not specified in package.json it will use the dependency of the parent nx project, which is `~13.3.0` at the moment. This can be seen when adding ng-keyboard-shortcut to a project and inspecting the pulled package.json. Using this library with anything other than Angular 13 does not work.

This PR adds `@angular/animations` and thus, `@angular/compiler` to the peer dependencies of the library