### PR TITLE
converted help page 'showing' flag to BehaviorSubject

### DIFF
--- a/libs/ng-keyboard-shortcuts/src/lib/ng-keyboard-shortcuts-help.component.html
+++ b/libs/ng-keyboard-shortcuts/src/lib/ng-keyboard-shortcuts-help.component.html
@@ -1,6 +1,6 @@
 <ng-template>
     <div class="help-modal__container" [attr.aria-labelledby]="'modal-' + title" role="dialog">
-        <div class="{{className}}" [@enterAnimation] *ngIf="showing">
+        <div class="{{className}}" [@enterAnimation] *ngIf="showing$ | async">
             <div class="title">
                 <h3 id="modal-{{title}}" class="title__text">{{title}}</h3>
             </div>
@@ -20,6 +20,6 @@
                 </div>
             </div>
         </div>
-        <div class="help-modal__backdrop" [@overlayAnimation] (mousedown)="hide()" *ngIf="showing"></div>
+        <div class="help-modal__backdrop" [@overlayAnimation] (mousedown)="hide()" *ngIf="showing$ | async"></div>
     </div>
 </ng-template>

--- a/libs/ng-keyboard-shortcuts/src/lib/ng-keyboard-shortcuts-help.component.ts
+++ b/libs/ng-keyboard-shortcuts/src/lib/ng-keyboard-shortcuts-help.component.ts
@@ -219,7 +219,7 @@ export class KeyboardShortcutsHelpComponent implements OnInit, OnDestroy, OnChan
     /**
      * @ignore
      */
-    showing$: BehaviorSubject<boolean> = new BehaviorSubject(false);
+    showing$ = new BehaviorSubject(false);
     /**
      * @ignore
      */

--- a/libs/ng-keyboard-shortcuts/src/lib/ng-keyboard-shortcuts-help.component.ts
+++ b/libs/ng-keyboard-shortcuts/src/lib/ng-keyboard-shortcuts-help.component.ts
@@ -20,7 +20,7 @@ import { KeyboardShortcutsHelpService } from "./ng-keyboard-shortcuts-help.servi
 import { animate, style, transition, trigger } from "@angular/animations";
 import { distinctUntilChanged, map } from "rxjs/operators";
 import { groupBy } from "./utils";
-import { SubscriptionLike } from "rxjs";
+import { BehaviorSubject, SubscriptionLike } from "rxjs";
 import { Shortcut } from "./ng-keyboard-shortcuts.interfaces";
 
 /**
@@ -219,7 +219,7 @@ export class KeyboardShortcutsHelpComponent implements OnInit, OnDestroy, OnChan
     /**
      * @ignore
      */
-    showing = false;
+    showing$: BehaviorSubject<boolean> = new BehaviorSubject(false);
     /**
      * @ignore
      */
@@ -259,7 +259,7 @@ export class KeyboardShortcutsHelpComponent implements OnInit, OnDestroy, OnChan
         }
         const portal = new TemplatePortal(this.template, this.viewContainer);
         this.bodyPortalHost.attach(portal);
-        this.showing = true;
+        this.showing$.next(true);
         return this;
     }
 
@@ -282,7 +282,7 @@ export class KeyboardShortcutsHelpComponent implements OnInit, OnDestroy, OnChan
             return this;
         }
         this.bodyPortalHost.detach();
-        this.showing = false;
+        this.showing$.next(false);
         return this;
     }
 


### PR DESCRIPTION
I had issues in my project where the help screen wasn't popping up until extra keys were pressed. Converting a flag from boolean to BehaviorSubject<boolean> and referencing it with an async pipe fixed my issue.
