### PR TITLE
fix: use [closeKeyLabel] instead of ignoring it

### DIFF
--- a/libs/ng-keyboard-shortcuts/src/lib/ng-keyboard-shortcuts-help.component.ts
+++ b/libs/ng-keyboard-shortcuts/src/lib/ng-keyboard-shortcuts-help.component.ts
@@ -358,7 +358,7 @@ export class KeyboardShortcutsHelpComponent implements OnInit, OnDestroy, OnChan
             preventDefault: true,
             command: () => this.hide(),
             description: this.closeKeyDescription,
-            label: this.closeKeyDescription
+            label: this.closeKeyLabel
         });
     }
 }


### PR DESCRIPTION
Fix for closeKeyLabel is incorrectly using the closeKeyDescription property when rending help modal.